### PR TITLE
Fix version file syntax error

### DIFF
--- a/BurstAtomicThrustModule.version
+++ b/BurstAtomicThrustModule.version
@@ -17,7 +17,6 @@
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 0
-  }
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,


### PR DESCRIPTION
Hi @linuxgurugamer,

![image](https://user-images.githubusercontent.com/1559108/126238404-c676ca27-1824-4c2d-a62f-61821ac6b857.png)

There's an extra `}` character.
